### PR TITLE
fix: add delimiter to avoid matching "-beta" versions

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -11,7 +11,7 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: regex
-        pattern: 'go1.(\d*).(\d*)'
+        pattern: 'go1\.(\d*)\.(\d*)$'
     transformers:
       - trimPrefix: "go"
   updatedGoMod:


### PR DESCRIPTION
With the original regexp, `go1.18-beta` is matched