### PR TITLE
fix: customizable OpenVPN `server.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ This image can be configured at runtime with different environment variables:
 * `AUTH_LDAP_URL` **Define ldap endpoint url**
 * `AUTH_LDAP_PASSWORD` **Define user dn password**
 * `AUTH_LDAP_GROUPS_MEMBER` **Define required group member to authenticate**
+* `OPENVPN_NETWORK_NAME` **Define the network name from config.yaml to use**
+* `OPENVPN_SERVER_SUBNET` **Define the VPN subnet**
+* `OPENVPN_SERVER_MASK` **Define the mask associated to the VPN subnet**
 
 Some examples can be found inside [docker-compose.yaml](docker/docker-compose.yaml)
 

--- a/docker/config/server.conf
+++ b/docker/config/server.conf
@@ -93,7 +93,7 @@ topology subnet
 # Each client will be able to reach the server
 # on 10.8.0.1. Comment this line out if you are
 # ethernet bridging. See the man page for more info.
-server 10.8.0.0 255.255.254.0 'nopool'
+server OPENVPN_SERVER_SUBNET OPENVPN_SERVER_MASK 'nopool'
 
 # Maintain a record of client <-> virtual IP address
 # associations in this file.  If OpenVPN goes down or

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,7 +13,9 @@ services:
         - "AUTH_LDAP_URL=ldaps://ldap"
         - "AUTH_LDAP_BINDDN=cn=admin,dc=jenkins-ci,dc=org"
         - "AUTH_LDAP_GROUPS_MEMBER=cn=all"
-        - "OPENVPN_NETWORK=mocked-vnet"
+        - "OPENVPN_NETWORK_NAME=mocked-vnet"
+        - "OPENVPN_SERVER_SUBNET=10.8.0.0"
+        - "OPENVPN_SERVER_MASK=255.255.254.0"
     volumes:
         - ./mock/vpn/ccd:/home/openvpn/available-ccds:ro
         - ./mock/vpn/ca.crt:/etc/openvpn/server/ca.crt:ro

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,7 +11,7 @@ function ensure_required_variables {
   : "${AUTH_LDAP_GROUPS_MEMBER:? AUTH_LDAP_GROUPS_MEMBER required}"
   : "${OPENVPN_SERVER_SUBNET:? OPENVPN_SERVER_SUBNET required}"
   : "${OPENVPN_SERVER_MASK:? OPENVPN_SERVER_MASK required}"
-  : "${OPENVPN_NETWORK:? OPENVPN_NETWORK required}"
+  : "${OPENVPN_NETWORK_NAME:? OPENVPN_NETWORK_NAME required}"
 }
 
 function configure_tun {
@@ -49,7 +49,7 @@ function configure_certificates {
 
 function copy_client_configurations_directory {
   mkdir -p /etc/openvpn/server/ccd
-  cp /home/openvpn/available-ccds/${OPENVPN_NETWORK}/* /etc/openvpn/server/ccd
+  cp /home/openvpn/available-ccds/${OPENVPN_NETWORK_NAME}/* /etc/openvpn/server/ccd
 }
 
 # Use ~ in order to avoid wrong interpration with / in sed command.


### PR DESCRIPTION
Allow changing server.conf values with env vars

Follow-up of https://github.com/jenkins-infra/docker-openvpn/pull/212