### PR TITLE
fix(updatecli): remove Jenkinsfile_k8s target for the golang manifest

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -38,7 +38,7 @@ sources:
 
 conditions:
   checkForDockerImage:
-    name: "Check for a Docker image golang:<versions> used by the Makefile and Jenkinsfiles"
+    name: "Check for a Docker image golang:<versions> used by the Makefile"
     kind: dockerimage
     disablesourceinput: true
     spec:
@@ -62,17 +62,6 @@ targets:
       file: ./utils/easyvpn/Makefile
       matchpattern: 'GOLANG_VERSION \?= .*'
       replacepattern: 'GOLANG_VERSION ?= {{ source "latestGoVersion" }}'
-    scmid: default
-  updateJenkinsfile:
-    name: "Update the golang docker image version for the Jenkinsfile pod container agent"
-    sourceid: latestGoVersion
-    kind: file
-    spec:
-      file: ./Jenkinsfile_k8s
-      matchpattern: >-
-        'golang:.*'
-      replacepattern: >-
-        'golang:{{ source `latestGoVersion` }}'
     scmid: default
 
 actions:


### PR DESCRIPTION
Noticed the following error in https://infra.ci.jenkins.io/blue/organizations/jenkins/docker-jobs%2Fdocker-openvpn/detail/PR-242/4/pipeline:

> [2023-02-24T13:18:08.749Z] updateGomod
> [2023-02-24T13:18:08.749Z] -----------
> [2023-02-24T13:18:08.749Z] 
> [2023-02-24T13:18:08.749Z] **Dry Run enabled**
> [2023-02-24T13:18:08.750Z] 
> [2023-02-24T13:18:08.807Z] vendor/golang.org/x/text/unicode/bidi
> [2023-02-24T13:18:08.807Z] vendor/golang.org/x/text/unicode/norm
> [2023-02-24T13:18:09.008Z] ✔ Content from file "/tmp/updatecli/github/jenkins-infra/openvpn/utils/easyvpn/go.mod" already up to date
> [2023-02-24T13:18:09.008Z] ✔ All contents from 'file' and 'files' combined already up to date
> [2023-02-24T13:18:09.008Z] 
> [2023-02-24T13:18:09.008Z] ERROR: something went wrong in target "updateJenkinsfile" : "No line matched in the file \"/tmp/updatecli/github/jenkins-infra/openvpn/Jenkinsfile_k8s\" for the pattern \"'golang:.*'\""
> [2023-02-24T13:18:09.008Z] 
> [2023-02-24T13:18:09.008Z] Pipeline "Bump golang version" failed
> [2023-02-24T13:18:09.008Z] Skipping due to:
> [2023-02-24T13:18:09.008Z] 	targets stage:	"something went wrong during target execution"
