### PR TITLE
chore(updatecli) fix golang mod update script

### DIFF
--- a/updatecli/scripts/updateGomodGoversion.sh
+++ b/updatecli/scripts/updateGomodGoversion.sh
@@ -13,19 +13,15 @@ go_version="${2}"
 new_version="$(echo "${go_version}" | cut -d. -f1,2)"
 tmp_dir="$(mktemp -d)"
 
-## Ensures that there is a golang version installed
+## Get the new golang version to use
+go_bin="${tmp_dir}"/.bin/go/bin/go
 {
-  if ! command -v go
-  then
-    curl --silent --show-error --location --output "${tmp_dir}/go.tgz" \
-      "https://golang.org/dl/go${go_version}.$(uname -s | tr '[:upper:]' '[:lower:]')-amd64.tar.gz"
-    mkdir -p "${tmp_dir}/.bin"
-    tar xzf "${tmp_dir}/go.tgz" -C "${tmp_dir}/.bin"
-    export PATH="${PATH}":"${tmp_dir}"/.bin/go/bin
-  fi
-
-  command -v go
-  go version
+  curl --silent --show-error --location --output "${tmp_dir}/go.tgz" \
+    "https://golang.org/dl/go${go_version}.$(uname -s | tr '[:upper:]' '[:lower:]')-amd64.tar.gz"
+  mkdir -p "${tmp_dir}/.bin"
+  tar xzf "${tmp_dir}/go.tgz" -C "${tmp_dir}/.bin"
+  export PATH="${PATH}":"${tmp_dir}"/.bin/go/bin
+  "${go_bin}" version
 } >&2
 
 ## Copy go mod's directory to a temp directory an start working from this temp. dir.
@@ -35,8 +31,8 @@ GOPATH="$(mktemp -d)"
 export GOPATH
 
 ## Update go mod properly
-go mod edit -go="${new_version}" >&2
-go mod tidy >&2
+"${go_bin}" mod edit -go="${new_version}" >&2
+"${go_bin}" mod tidy >&2
 echo "" >> go.mod ## Ad empty endline to be POSIX compliant
 
 ## Show new go mod


### PR DESCRIPTION
The script used any existing installation of golang but:

- As soon as it uses a non PATH-located directory (or management tooling such as `asdf`) then it fails
- There is a dependency on the existing golang installation while we want the new version