### PR TITLE
feat: allow routing to cert-ci vnet for JenSec and JenInfra team members

### DIFF
--- a/cert/ccd/private/danielbeck
+++ b/cert/ccd/private/danielbeck
@@ -5,3 +5,5 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.248.0.0 255.252.0.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"

--- a/cert/ccd/private/dduportal
+++ b/cert/ccd/private/dduportal
@@ -5,3 +5,5 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.248.0.0 255.252.0.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"

--- a/cert/ccd/private/hlemeur
+++ b/cert/ccd/private/hlemeur
@@ -5,3 +5,5 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.248.0.0 255.252.0.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"

--- a/cert/ccd/private/kevingrdj
+++ b/cert/ccd/private/kevingrdj
@@ -5,3 +5,5 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.248.0.0 255.252.0.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"

--- a/cert/ccd/private/smerle
+++ b/cert/ccd/private/smerle
@@ -5,3 +5,5 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.248.0.0 255.252.0.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"

--- a/cert/ccd/private/wfollonier
+++ b/cert/ccd/private/wfollonier
@@ -5,3 +5,5 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.248.0.0 255.252.0.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"

--- a/cert/ccd/private/yafenkin
+++ b/cert/ccd/private/yafenkin
@@ -5,3 +5,5 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.248.0.0 255.252.0.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"

--- a/config.yaml
+++ b/config.yaml
@@ -22,3 +22,6 @@ networks:
           - 10.244.0.0/14
           # public-db vnet, defined in jenkins-infra/azure-net
           - 10.252.0.0/21
+          # cert-ci-jenkins-io vnet, defined in jenkins-infra/azure-net
+          # TODO: add manually to users whom require access to this instance (JenSec, Infra)
+          # - 10.252.8.0/21


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3688

This PR adds **manually** the routing rule on a few selected users to allow their VPN setup to route to the cert-ci-jenkins-io network.