### PR TITLE
feat: add the new (sponsored) vnet routes to CCDs

### DIFF
--- a/cert/ccd/private/danielbeck
+++ b/cert/ccd/private/danielbeck
@@ -1,11 +1,19 @@
 ifconfig-push 10.9.0.5 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/dduportal
+++ b/cert/ccd/private/dduportal
@@ -1,11 +1,19 @@
 ifconfig-push 10.9.0.3 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/halkeye
+++ b/cert/ccd/private/halkeye
@@ -1,7 +1,11 @@
 ifconfig-push 10.9.0.6 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"

--- a/cert/ccd/private/hlemeur
+++ b/cert/ccd/private/hlemeur
@@ -1,11 +1,19 @@
 ifconfig-push 10.9.0.2 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/kevingrdj
+++ b/cert/ccd/private/kevingrdj
@@ -1,11 +1,19 @@
 ifconfig-push 10.9.0.11 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/krisstern
+++ b/cert/ccd/private/krisstern
@@ -1,4 +1,11 @@
 ifconfig-push 10.9.0.15 255.255.255.0
-push "route 10.248.0.0 255.252.0.0"
+# public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
+# private vnet
+push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
+# public-db vnet
 push "route 10.252.0.0 255.255.248.0"

--- a/cert/ccd/private/lemeurherveCB
+++ b/cert/ccd/private/lemeurherveCB
@@ -1,4 +1,11 @@
 ifconfig-push 10.9.0.14 255.255.255.0
-push "route 10.248.0.0 255.252.0.0"
+# public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
+# private vnet
+push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
+# public-db vnet
 push "route 10.252.0.0 255.255.248.0"

--- a/cert/ccd/private/markewaite
+++ b/cert/ccd/private/markewaite
@@ -1,7 +1,19 @@
 ifconfig-push 10.9.0.7 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
+# trusted-ci-jenkins-io vnet
+push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/notmyfault
+++ b/cert/ccd/private/notmyfault
@@ -1,9 +1,19 @@
 ifconfig-push 10.9.0.8 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/smerle
+++ b/cert/ccd/private/smerle
@@ -1,11 +1,19 @@
 ifconfig-push 10.9.0.4 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/smerleCB
+++ b/cert/ccd/private/smerleCB
@@ -1,7 +1,11 @@
 ifconfig-push 10.9.0.13 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"

--- a/cert/ccd/private/timja
+++ b/cert/ccd/private/timja
@@ -1,9 +1,19 @@
 ifconfig-push 10.9.0.9 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
+# cert-ci-jenkins-io vnet
+push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/wfollonier
+++ b/cert/ccd/private/wfollonier
@@ -1,11 +1,19 @@
 ifconfig-push 10.9.0.10 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"

--- a/cert/ccd/private/yafenkin
+++ b/cert/ccd/private/yafenkin
@@ -1,11 +1,19 @@
 ifconfig-push 10.9.0.12 255.255.255.0
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
+# public-sponsorship vnet
+push "route 10.200.0.0 255.252.0.0"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
+# infra-ci-sponsorship vnet
+push "route 10.206.0.0 255.255.254.0"
 # public-db vnet
 push "route 10.252.0.0 255.255.248.0"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# cert-ci-jenkins-io-sponsorship vnet
+push "route 10.205.8.0 255.255.255.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
+# trusted-ci-jenkins-io-sponsorship vnet
+push "route 10.204.0.0 255.255.255.0"


### PR DESCRIPTION
Since https://github.com/jenkins-infra/helpdesk/issues/3818, there is a whole lot bunch of new virtual networks.

Our VPN setups should be aware of these new routes otherwise we can't reach new VMs such as in https://github.com/jenkins-infra/helpdesk/issues/3913


For proper review or audit: list of vnet and their CIDRs are defined here: https://github.com/jenkins-infra/azure-net/blob/main/vnets.tf