### PR TITLE
chore(pipeline) use "all in one" `arm64` agent instead of `amd64` deprecated `jenkinsciinfra/hashicorp-tools` 

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -3,25 +3,12 @@ properties([buildDiscarder(logRotator(daysToKeepStr: '15'))])
 parallel(
   failFast: true,
   'Build Easyvpn': {
-    podTemplate(
-      containers: [
-        containerTemplate(
-          name: 'jnlp',
-          image: 'jenkinsciinfra/hashicorp-tools:latest',
-          resourceRequestCpu: '2',
-          resourceLimitCpu: '2',
-          resourceRequestMemory: '2Gi',
-          resourceLimitMemory: '2Gi',
-        ),
-      ]
-    ) {
-      node(POD_LABEL) {
-        checkout scm
-        dir('utils/easyvpn') {
-          sh 'make build_linux'
-        }
+    node('linux-arm64') {
+      checkout scm
+      dir('utils/easyvpn') {
+        sh 'make build_linux'
       }
-    }
+    }    
   },
   'docker-and-updatecli': {
     parallelDockerUpdatecli([imageName: 'openvpn'])

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -8,7 +8,7 @@ parallel(
       dir('utils/easyvpn') {
         sh 'make build_linux'
       }
-    }    
+    }
   },
   'docker-and-updatecli': {
     parallelDockerUpdatecli([imageName: 'openvpn'])


### PR DESCRIPTION
as per https://github.com/jenkins-infra/docker-openvpn/pull/328#issuecomment-1945555172

I forgot to update this pipeline to use the new allinone agent