### PR TITLE
draft updatecli vnet

### DIFF
--- a/updatecli/scripts/CIDRtoNetmask.sh
+++ b/updatecli/scripts/CIDRtoNetmask.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script converts a CIDR notation to a netmask.
+# Function: cidr_to_netmask
+# Description: This function takes a CIDR value as input and returns the corresponding netmask.
+# Parameters:
+#   $1 - The CIDR value (e.g., 14 from 10.0.0.0/14)
+
+cidr_to_netmask() {
+    # Calculate the netmask value from the CIDR
+    value=$(( 0xffffffff ^ (1 << ( 32 - $1 )) - 1 ))
+    # Print the netmask in the format xxx.xxx.xxx.xxx
+    echo "$(( (value >> 24) & 0xff )).$(( (value >> 16) & 0xff )).$(( (value >> 8) & 0xff )).$(( value & 0xff ))"
+}
+
+# Check if a command line argument is provided
+# If not, print an error message and exit the script
+if [ $# -eq 0 ]; then
+    echo "No arguments provided. Please provide a CIDR value."
+    exit 1
+fi
+
+# Extract the CIDR value from the IP/CIDR string
+# This allows the script to accept input in the format xxx.xxx.xxx.xxx/yy
+cidr="${1#*/}"
+
+# Call the cidr_to_netmask function with the extracted CIDR value
+netmask=$(cidr_to_netmask "${cidr}")
+
+echo "${1%/*} ${netmask}"

--- a/updatecli/scripts/generate-updatecli-manifests.sh
+++ b/updatecli/scripts/generate-updatecli-manifests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script loops through all files in a the private certificates folder
+# and for each file update the correspondings manifests depending on the vnets in comments
+
+# Define the directory to loop through
+directory="./cert/ccd/private"
+
+# Loop through all files in the directory
+for file in "$directory"/*; do
+    # Check if the item is a file
+    if [ -f "$file" ]; then
+        file=./cert/ccd/private/smerle #debug
+        echo "Processing file: $file"
+        # for each couple comment/line check the corresponding manifest
+        # Extract two consecutive lines
+        # Skip the first line and process every two subsequent lines
+        tail -n +2 "$file" | while read -r comment; do
+            read -r command || break  # Read the second line, break if no more lines
+
+            # Print the comment and execute the command
+            echo "Comment: $comment"
+            echo "Executing: $command"
+            echo ""
+
+            # For each comment extract the vnet name and 
+
+        done
+        break
+    fi
+done

--- a/updatecli/updatecli.d/vnets.yaml
+++ b/updatecli/updatecli.d/vnets.yaml
@@ -1,0 +1,194 @@
+---
+name: Update Vnet public-vnet
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  public-vnet:
+    name: Get json informations
+    kind: json
+    scmid: default
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: "vnets.public-vnet.[0]"
+  public-vnet-digest:
+    name: Get vnet with correct netmask
+    kind: shell
+    # scmid: default
+    spec:
+      command: ./updatecli/scripts/CIDRtoNetmask.sh {{ source "public-vnet" }}
+
+targets:
+  update_smerle:
+    name: 'Update smerle public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/smerle
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_danielbeck:
+    name: 'Update danielbeck public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/danielbeck
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_dduportal:
+    name: 'Update dduportal public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/dduportal
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_halkeye:
+    name: 'Update halkeye public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/halkeye
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_hlemeur:
+    name: 'Update hlemeur public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/hlemeur
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_kevingrdj:
+    name: 'Update kevingrdj public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/kevingrdj
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_krisstern:
+    name: 'Update krisstern public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/krisstern
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_lemeurherveCB:
+    name: 'Update lemeurherveCB public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/lemeurherveCB
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_markewaite:
+    name: 'Update markewaite public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/markewaite
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_notmyfault:
+    name: 'Update notmyfault public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/notmyfault
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_smerleCB:
+    name: 'Update smerleCB public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/smerleCB
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_timja:
+    name: 'Update timja public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/timja
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_wfollonier:
+    name: 'Update wfollonier public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/wfollonier
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+  update_yafenkin:
+    name: 'Update yafenkin public-vnets {{ source "public-vnet-digest" }}'
+    kind: file
+    sourceid: public-vnet-digest
+    spec:
+      file: ./cert/ccd/private/yafenkin
+      matchpattern: >-
+        (# public vnet.*\npush "route )(.*)"
+      replacepattern: >-
+        ${1}{{ source "public-vnet-digest" }}"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update smerle public-vnets {{ source "public-vnet-digest" }}
+    spec:
+      labels:
+        - network


### PR DESCRIPTION
for memory, 
this would need more improvement and time.

- changing the report to deal with the netmask format with terraform
- changing the template in yaml that create the new user file, to be updated too
- dealing with the update of the updatecli manifest directly from the go code (new users/delete users)
- and from another updatecli for the new vnet

maybee be wiser to fit most in updatecli and just the template in go ... 

need to be analysed.