### PR TITLE
feat(ccds) add routes to the pkg, census, usage and archives VM through the VPN

### DIFF
--- a/cert/ccd/private/danielbeck
+++ b/cert/ccd/private/danielbeck
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/dduportal
+++ b/cert/ccd/private/dduportal
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/hlemeur
+++ b/cert/ccd/private/hlemeur
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/kevingrdj
+++ b/cert/ccd/private/kevingrdj
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/markewaite
+++ b/cert/ccd/private/markewaite
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/notmyfault
+++ b/cert/ccd/private/notmyfault
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/smerle
+++ b/cert/ccd/private/smerle
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/timja
+++ b/cert/ccd/private/timja
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/cert/ccd/private/wfollonier
+++ b/cert/ccd/private/wfollonier
@@ -17,3 +17,11 @@ push "route 10.205.8.0 255.255.255.0"
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
+# archives.jenkins.io VM
+push "route 46.101.121.132 255.255.255.255"
+# pkg.origin.jenkins.io VM
+push "route 52.202.51.185 255.255.255.255"
+# usage.jenkins.io VM
+push "route 52.204.62.78 255.255.255.255"
+# census.jenkins.io VM
+push "route 52.202.38.86 255.255.255.255"

--- a/config.yaml
+++ b/config.yaml
@@ -20,3 +20,11 @@ networks:
       # trusted-ci-jenkins-io vnet, defined in jenkins-infra/azure-net
       # TODO: add manually to users whom require access to this instance (JenSec, Infra)
       # - 10.252.0.0/21
+      # archives.jenkins.io VM
+      - 46.101.121.132/32
+      # pkg.origin.jenkins.io VM
+      - 52.202.51.185/32
+      # usage.jenkins.io VM
+      - 52.204.62.78/32
+      # census.jenkins.io VM
+      - 52.202.38.86/32


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4196

This PR adds the routes to the CCDs of the "usual suspects" and to the default configuration for new CCDs.