### PR TITLE
feat(ccd) add 2 routes to the EKS cluster `cijenkinsio-agents-2`

### DIFF
--- a/cert/ccd/private/danielbeck
+++ b/cert/ccd/private/danielbeck
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/dduportal
+++ b/cert/ccd/private/dduportal
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/jayfranco_cb
+++ b/cert/ccd/private/jayfranco_cb
@@ -5,3 +5,6 @@ push "route 10.248.1.5 255.255.255.255"
 push "route 10.206.0.0 255.255.252.0"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/kevingrdj
+++ b/cert/ccd/private/kevingrdj
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/markewaite
+++ b/cert/ccd/private/markewaite
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/notmyfault
+++ b/cert/ccd/private/notmyfault
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/smerle
+++ b/cert/ccd/private/smerle
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/timja
+++ b/cert/ccd/private/timja
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/cert/ccd/private/wfollonier
+++ b/cert/ccd/private/wfollonier
@@ -27,3 +27,6 @@ push "route 52.204.62.78 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # aws.ci.jenkins.io VM
 push "route 3.146.166.108 255.255.255.255"
+# EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+push "route 3.146.156.247 255.255.255.255"
+push "route 3.130.164.212 255.255.255.255"

--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,6 @@ networks:
       - 52.202.38.86/32
       # aws.ci.jenkins.io VM
       - 3.146.166.108/32
+      # EKS cluster "cijenkinsio-agents-2" (2 public IPs)
+      - 3.146.156.247/32
+      - 3.130.164.212/32


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4319

Twin (client-side) of https://github.com/jenkins-infra/jenkins-infra/pull/3776

Current endpoint hostname is `BFED49033BB86D3FF1EF8DE8480E024B.gr7.us-east-2.eks.amazonaws.com` which resolve to 2 public IPv4s.