### PR TITLE
chore(GHA) use `ubuntu-latest` runner for Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -8,7 +8,7 @@ on:
 concurrency: "release-drafter"
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
         env:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2982