### PR TITLE
chore(Jenkinsfile_k8s): Remove automaticSemanticVersioning from script call

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -11,8 +11,6 @@ parallel(
     }
   },
   'docker-image': {
-    buildDockerAndPublishImage('openvpn', [
-      automaticSemanticVersioning: true,
-    ])
+    buildDockerAndPublishImage('openvpn')
   },
 )


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/2778

`automaticSemanticVersioning` is set to true by default, we no longer need to set the parameter in the script call.