### PR TITLE
feat(easyvpn)!: use map for networks in YAML config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,34 +1,32 @@
 # Follow network settings are used to assign ip to vpn client
 # and accesses are limited by
 # https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/manifests/openvpn.pp
-#
 networks:
-  - name: private
-    # Abstract local network for the VPN
-    iprange: 10.9.0.0/24
+  private:
+    iprange: 10.9.0.0/24 # dmz subnet which holds the principal network interface of the VPN VM
     netmask: 255.255.255.0
     routes:
-      # private-vnet, defined in jenkins-infra/azure-net
-      - 10.248.0.0/14
-      # private_sponsored-vnet, defined in jenkins-infra/azure-net
-      - 10.240.0.0/14
-      # public vnet, defined in jenkins-infra/azure-net
-      - 10.244.0.0/14
-      # public-db vnet, defined in jenkins-infra/azure-net
-      - 10.253.0.0/21
-      # cert-ci-jenkins-io vnet, defined in jenkins-infra/azure-net
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      private: 10.248.0.0/14
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      private-sponsored: 10.240.0.0/14
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      public: 10.244.0.0/14
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      public-db: 10.253.0.0/21
       # TODO: add manually to users whom require access to this instance (JenSec, Infra)
-      # - 10.252.8.0/21
-      # trusted-ci-jenkins-io vnet, defined in jenkins-infra/azure-net
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      cert.ci.jenkins.io: 10.252.8.0/21
       # TODO: add manually to users whom require access to this instance (JenSec, Infra)
-      # - 10.252.0.0/21
-      # archives.jenkins.io VM
-      - 46.101.121.132/32
-      # pkg.origin.jenkins.io VM
-      - 52.202.51.185/32
-      # usage.jenkins.io VM
-      - 52.204.62.78/32
-      # census.jenkins.io VM
-      - 52.202.38.86/32
-      # azure.ci.jenkins.io VM
-      - 172.200.138.43/32
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      trusted.ci.jenkins.io: 10.252.0.0/21
+      # TODO: track with updatecli (Digital Ocean)
+      archives.jenkins.io: 46.101.121.132/32
+      # TODO: track with updatecli (AWS CloudBees)
+      pkg.origin.jenkins.io: 52.202.51.185/32
+      # TODO: track with updatecli (AWS CloudBees)
+      usage.jenkins.io: 52.204.62.78/32
+      # TODO: track with updatecli (AWS CloudBees)
+      census.jenkins.io: 52.202.38.86/32
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      azure.ci.jenkins.io: 172.200.138.43/32

--- a/utils/easyvpn/cmd/config.go
+++ b/utils/easyvpn/cmd/config.go
@@ -44,12 +44,11 @@ var configCmd = &cobra.Command{
 				}
 			}
 		} else {
+			globalConfig := network.ReadConfigFile(config)
 
-			config := network.ReadConfigFile(config)
-			network, err := config.GetNetworkByName(net)
-
-			if err != nil {
-				fmt.Println(err)
+			network, ok := globalConfig.Networks[net]
+			if !ok {
+				fmt.Printf("Network %s not found: check config file %s.\n", net, config)
 				os.Exit(1)
 			}
 

--- a/utils/easyvpn/cmd/sign.go
+++ b/utils/easyvpn/cmd/sign.go
@@ -45,12 +45,11 @@ var signCmd = &cobra.Command{
 		}
 
 		// Generate client config
-		config := network.ReadConfigFile(config)
+		globalConfig := network.ReadConfigFile(config)
 
-		network, err := config.GetNetworkByName(net)
-
-		if err != nil {
-			fmt.Println(err)
+		network, ok := globalConfig.Networks[net]
+		if !ok {
+			fmt.Printf("Network %s not found: check config file %s.\n", net, config)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
As https://github.com/jenkins-infra/docker-openvpn/pull/404 shows, using an array to express the networks is fragile: keeping it up to date (with `updatecli` or any other tool) depends on the order.

This PR changes the code of `easyvpn` to that we use a map: no order as we use the networks name as keys instead.


Tested localy with the new `easyvpn` go build with:
- Trying to generater a new user `foo` and checked its CCD is ok:

```
./easyvpn request --commit=false --push=false foo
./easyvpn sign --commit=false --push=false foo
```
- Tested the command `easyvpn check` is still successful and shows the production certs.