### PR TITLE
chore(easyvpn) enable golangci lint and fix checker warnings

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -6,6 +6,7 @@ parallel(
     node('linux-arm64') {
       checkout scm
       dir('utils/easyvpn') {
+        sh 'make lint'
         sh 'make build_linux'
       }
     }

--- a/utils/easyvpn/Makefile
+++ b/utils/easyvpn/Makefile
@@ -2,6 +2,9 @@
 
 GOLANG_VERSION ?= 1.24.3
 
+lint:
+	golangci-lint run
+
 build_osx:
 	go mod download
 	GO111MODULE=on CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -v .

--- a/utils/easyvpn/cmd/config.go
+++ b/utils/easyvpn/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 
@@ -31,9 +32,14 @@ var configCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 
-		if delete == true {
+		if delete {
 			for j := range args {
-				network.DeleteClientConfig(path.Join(ccd, net, args[j]))
+				err := network.DeleteClientConfig(path.Join(ccd, net, args[j]))
+				if err != nil {
+					log.Fatal(err)
+					os.Exit(1)
+				}
+
 				if commit {
 					msg := fmt.Sprintf("[infra-admin] Delete %v in '%v' network configuration", args[j], net)
 					files := []string{
@@ -53,7 +59,10 @@ var configCmd = &cobra.Command{
 			}
 
 			for j := 0; j < len(args); j++ {
-				network.CreateClientConfig(args[j], path.Join(ccd, net))
+				err := network.CreateClientConfig(args[j], path.Join(ccd, net))
+				if err != nil {
+					panic(err)
+				}
 
 				if commit {
 					msg := fmt.Sprintf("[infra-admin] Update %v in '%v' network configuration", args[j], net)

--- a/utils/easyvpn/cmd/request.go
+++ b/utils/easyvpn/cmd/request.go
@@ -22,11 +22,9 @@ var requestCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		errors := easyrsa.RequestClientCert(args)
-		if errors != nil {
-			for _, err := range errors {
-				if err != nil {
-					fmt.Printf("%v\n", err)
-				}
+		for _, err := range errors {
+			if err != nil {
+				fmt.Printf("%v\n", err)
 			}
 		}
 		if Commit {

--- a/utils/easyvpn/cmd/revoke.go
+++ b/utils/easyvpn/cmd/revoke.go
@@ -27,15 +27,16 @@ var revokeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		helpers.DecryptPrivateDir()
 		errors := easyrsa.RevokeClientCert(args)
-		if errors != nil {
-			for _, err := range errors {
-				if err != nil {
-					fmt.Printf("%v\n", err)
-				}
+		for _, err := range errors {
+			if err != nil {
+				fmt.Printf("%v\n", err)
 			}
 		}
 		for i := range args {
-			network.DeleteClientConfig(path.Join(CertDir, "ccd", Network, args[i]))
+			err := network.DeleteClientConfig(path.Join(CertDir, "ccd", Network, args[i]))
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		fileToDelete := []string{

--- a/utils/easyvpn/cmd/sign.go
+++ b/utils/easyvpn/cmd/sign.go
@@ -36,11 +36,9 @@ var signCmd = &cobra.Command{
 		// Sign requested certificate(s)
 		helpers.DecryptPrivateDir()
 		errors := easyrsa.SignClientRequest(args)
-		if errors != nil {
-			for _, err := range errors {
-				if err != nil {
-					fmt.Printf("%v\n", err)
-				}
+		for _, err := range errors {
+			if err != nil {
+				fmt.Printf("%v\n", err)
 			}
 		}
 
@@ -54,7 +52,10 @@ var signCmd = &cobra.Command{
 		}
 
 		for i := range args {
-			network.CreateClientConfig(args[i], path.Join(ccd, net))
+			err := network.CreateClientConfig(args[i], path.Join(ccd, net))
+			if err != nil {
+				panic(err)
+			}
 
 			// Commit changes
 			if commit {

--- a/utils/easyvpn/git/main.go
+++ b/utils/easyvpn/git/main.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 )
 
-var debug = false
-
 const defaultBranch string = "main"
 
 func git(args ...string) (string, error) {
@@ -34,28 +32,36 @@ func git(args ...string) (string, error) {
 // Commit create a new commit
 func Commit(files []string, msg string) {
 	args := []string{"commit"}
-	for _, file := range files {
-		args = append(args, file)
-	}
+	args = append(args, files...)
 	args = append(args, "-m")
 	args = append(args, msg)
 
-	git(args...)
+	out, err := git(args...)
+	if err != nil {
+		fmt.Println(out)
+		panic(err)
+	}
 }
 
 // Add create a new commit
 func Add(files []string) {
 	args := []string{"add"}
-	for _, file := range files {
-		args = append(args, file)
+	args = append(args, files...)
+	out, err := git(args...)
+	if err != nil {
+		fmt.Println(out)
+		panic(err)
 	}
-	git(args...)
 }
 
 // Pull fetch from origin
 func Pull() {
 	args := []string{"pull"}
-	git(args...)
+	out, err := git(args...)
+	if err != nil {
+		fmt.Println(out)
+		panic(err)
+	}
 }
 
 // getRepoOwner returns local branch
@@ -77,7 +83,7 @@ func getRepoOwner() (string, error) {
 	} else if strings.HasPrefix(url, "https://github.com/") {
 		owner = strings.Split(url, "/")[3]
 	} else {
-		err := fmt.Errorf("Couldn't find current repository owner in %v", url)
+		err := fmt.Errorf("couldn't find current repository owner in %v", url)
 		return "", err
 	}
 	fmt.Printf("Current repository owner: %v\n", owner)
@@ -88,16 +94,26 @@ func getRepoOwner() (string, error) {
 func Push() {
 	branch := getLocalBranch()
 	owner, err := getRepoOwner()
-	args := []string{"push"}
-	git(args...)
-
-	if err == nil {
-		fmt.Printf("You can now open your Pull Request via \n\t https://github.com/jenkins-infra/docker-openvpn/compare/%v...%v:%v\n", defaultBranch, owner, branch)
+	if err != nil {
+		panic(err)
 	}
+
+	args := []string{"push"}
+	out, err := git(args...)
+	if err != nil {
+		fmt.Println(out)
+		panic(err)
+	}
+
+	fmt.Printf("You can now open your Pull Request via \n\t https://github.com/jenkins-infra/docker-openvpn/compare/%v...%v:%v\n", defaultBranch, owner, branch)
 }
 
 // Rebase from origin
 func Rebase() {
 	args := []string{"rebase", fmt.Sprintf("origin/%v", defaultBranch)}
-	git(args...)
+	out, err := git(args...)
+	if err != nil {
+		fmt.Println(out)
+		panic(err)
+	}
 }

--- a/utils/easyvpn/helpers/main.go
+++ b/utils/easyvpn/helpers/main.go
@@ -21,13 +21,19 @@ func DecryptPrivateDir() {
 
 		file, err := os.Create(dirname + file)
 		if err != nil {
-			log.Fatal(err)
+			panic(err)
 		}
 
-		defer file.Close()
-		fmt.Fprintf(file, "%s", string(out))
+		defer func() {
+			if err := file.Close(); err != nil {
+				panic(err)
+			}
+		}()
+		_, err = fmt.Fprintf(file, "%s", string(out))
+		if err != nil {
+			panic(err)
+		}
 	}
-
 }
 
 // CleanPrivateDir delete decrypte ca private key and the file containing his password

--- a/utils/easyvpn/network/main.go
+++ b/utils/easyvpn/network/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"text/template"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Config represents a list of network

--- a/utils/easyvpn/network/main.go
+++ b/utils/easyvpn/network/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path"
@@ -102,8 +103,12 @@ func readClientConfigFile(cn string) (ip, mask string) {
 	var IP, netmask string
 	file, err := os.Open(cn)
 	CheckErr(err)
+	defer func() {
+		if err := file.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
-	defer file.Close()
 	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {
@@ -142,16 +147,22 @@ func isClientConfigured(cn string, clientNetwork string) bool {
 	}
 
 	file, err := os.Open(cn)
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			panic(err)
+		}
+	}()
 	CheckErr(err)
 
 	ip, _ := readClientConfigFile(cn)
 
 	_, network, err := net.ParseCIDR(clientNetwork)
-	if network.Contains(net.ParseIP(ip)) {
-		return true
+	if err != nil {
+		log.Fatalf("%s\n", err)
+		return false
 	}
-	return false
+
+	return network.Contains(net.ParseIP(ip))
 }
 
 // DeleteClientConfig remove a client network configuration
@@ -197,7 +208,11 @@ func (n *Network) CreateClientConfig(cn string, ccd string) error {
 
 	file, err := os.Create(path.Join(ccd, cn))
 	CheckErr(err)
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
 	err = tmpl.Execute(file, config)
 
@@ -207,17 +222,24 @@ func (n *Network) CreateClientConfig(cn string, ccd string) error {
 
 func (n *Network) getFreeIP(ccd string) (string, error) {
 	_, network, err := net.ParseCIDR(n.IPRange)
-
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
+
 	networkMask, _ := network.Mask.Size()
 	networkIP := network.IP.String()
 
 	networkCIDR := fmt.Sprintf("%v/%v", networkIP, networkMask)
 
 	iprange, err := n.iprange()
+	if err != nil {
+		return "", err
+	}
+
 	ipUsed, err := getAllUsedIP(ccd)
+	if err != nil {
+		return "", err
+	}
 
 	for j := range ipUsed {
 		// Restart from 0 as ipUsed is not sorted


### PR DESCRIPTION
- Lint enabled with a new Make target: `lint`,
- which is called by the pipeline
- Applied all messages from the linter (a lot of ineffectual assignemnt, missing `errchecks`, unused variables, etc.)
- Note: We rely on the `golangci-lint` installed on the agents machines (https://github.com/jenkins-infra/packer-images/blob/68eba541d19885223144cd6d32eca550688e9f7d/provisioning/tools-versions.yml#L17)