### PR TITLE
fix(easyvpn) ensure user provided flags behave as expected

### DIFF
--- a/utils/easyvpn/cmd/check.go
+++ b/utils/easyvpn/cmd/check.go
@@ -9,7 +9,8 @@ import (
 
 func init() {
 	rootCmd.AddCommand(checkCmd)
-	checkCmd.Flags().StringVarP(&CertDir, "cert", "c", "cert", "Cert Directory")
+	checkCmd.Flags().StringVarP(&certDir, "cert", "c", "cert", "Cert Directory")
+	checkCmd.Flags().StringVarP(&mainNetwork, "net", "", "private", "Network assigned")
 }
 
 var checkCmd = &cobra.Command{
@@ -19,10 +20,10 @@ var checkCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		rc := 0
 
-		if result, _ := checks.IsAllCertsSigned(CertDir); !result {
+		if result, _ := checks.IsAllCertsSigned(certDir); !result {
 			rc = 1
 		}
-		if result, _ := checks.IsAllClientConfigured(CertDir, Network); !result {
+		if result, _ := checks.IsAllClientConfigured(certDir, mainNetwork); !result {
 			rc = 1
 		}
 

--- a/utils/easyvpn/cmd/main.go
+++ b/utils/easyvpn/cmd/main.go
@@ -1,12 +1,11 @@
 package cmd
 
 var (
-	certDir       string
-	commit        bool
-	config        string
-	push          bool
-	delete        bool
-	ccd           string
-	configuration string
-	net           string
+	certDir          string
+	commit           bool
+	push             bool
+	delete           bool
+	clientConfigsDir string
+	configuration    string
+	mainNetwork      string
 )

--- a/utils/easyvpn/cmd/request.go
+++ b/utils/easyvpn/cmd/request.go
@@ -11,9 +11,9 @@ import (
 
 func init() {
 	rootCmd.AddCommand(requestCmd)
-	requestCmd.Flags().BoolVarP(&Commit, "commit", "", true, "git commit changes")
-	requestCmd.Flags().BoolVarP(&Push, "push", "", true, "git push changes")
-	requestCmd.Flags().StringVarP(&CertDir, "cert", "c", "cert", "Cert Directory")
+	requestCmd.Flags().BoolVarP(&commit, "commit", "", true, "git commit changes")
+	requestCmd.Flags().BoolVarP(&push, "push", "", true, "git push changes")
+	requestCmd.Flags().StringVarP(&certDir, "cert", "c", "cert", "Cert Directory")
 }
 
 var requestCmd = &cobra.Command{
@@ -27,18 +27,18 @@ var requestCmd = &cobra.Command{
 				fmt.Printf("%v\n", err)
 			}
 		}
-		if Commit {
+		if commit {
 			for i := range args {
 				msg := "[infra-admin] Submit certificate request for " + args[i]
 				files := []string{
-					path.Join(CertDir, "pki/reqs", args[i]+".req"),
+					path.Join(certDir, "pki/reqs", args[i]+".req"),
 				}
 				git.Add(files)
 				git.Commit(files, msg)
 			}
 		}
 
-		if Push {
+		if push {
 			git.Push()
 		}
 	},

--- a/utils/easyvpn/cmd/root.go
+++ b/utils/easyvpn/cmd/root.go
@@ -12,18 +12,6 @@ var rootCmd = &cobra.Command{
 	Short: "Easyvpn is a client tool to manage Jenkins Infrastructure VPN",
 }
 
-// CertDir define cert directory path
-var CertDir string
-
-// Net define network to use (determine the ccd to use)
-var Network string
-
-// Commit define if changes must be committed or not
-var Commit bool
-
-// Push define if changes must be pushed or not
-var Push bool
-
 // Execute run the main command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {

--- a/utils/easyvpn/cmd/sign.go
+++ b/utils/easyvpn/cmd/sign.go
@@ -17,9 +17,9 @@ func init() {
 	signCmd.Flags().BoolVarP(&commit, "commit", "", true, "git commit changes")
 	signCmd.Flags().BoolVarP(&push, "push", "", true, "git push changes")
 	signCmd.Flags().StringVarP(&certDir, "certsDir", "", "cert", "Cert Directory")
-	signCmd.Flags().StringVarP(&ccd, "ccd", "", "cert/ccd", "Client Config Directory")
-	signCmd.Flags().StringVarP(&config, "config", "", "config.yaml", "Network Configuration File")
-	signCmd.Flags().StringVarP(&net, "net", "n", "private", "Network to assign the cn")
+	signCmd.Flags().StringVarP(&clientConfigsDir, "ccd", "", "cert/ccd", "Client Config Directory")
+	signCmd.Flags().StringVarP(&configuration, "config", "", "config.yaml", "Network Configuration File")
+	signCmd.Flags().StringVarP(&mainNetwork, "net", "n", "private", "Network to assign the cn")
 }
 
 var signCmd = &cobra.Command{
@@ -37,16 +37,16 @@ var signCmd = &cobra.Command{
 		}
 
 		// Generate client config
-		globalConfig := network.ReadConfigFile(config)
+		globalConfig := network.ReadConfigFile(configuration)
 
-		network, ok := globalConfig.Networks[net]
+		network, ok := globalConfig.Networks[mainNetwork]
 		if !ok {
-			fmt.Printf("Network %s not found: check config file %s.\n", net, config)
+			fmt.Printf("Network %s not found: check config file %s.\n", mainNetwork, configuration)
 			os.Exit(1)
 		}
 
 		for i := range args {
-			err := network.CreateClientConfig(args[i], path.Join(ccd, net))
+			err := network.CreateClientConfig(args[i], path.Join(clientConfigsDir, mainNetwork))
 			if err != nil {
 				panic(err)
 			}
@@ -55,12 +55,12 @@ var signCmd = &cobra.Command{
 			if commit {
 				msg := "[infra-admin] Sign certificate request for " + args[i]
 				files := []string{
-					path.Join(CertDir, "pki/issued", args[i]+".crt"),
-					path.Join(CertDir, "pki", "index.txt"),
-					path.Join(CertDir, "pki", "index.txt.attr"),
-					path.Join(CertDir, "pki", "certs_by_serial"),
-					path.Join(CertDir, "pki", "serial"),
-					path.Join(CertDir, "ccd", net, args[i]),
+					path.Join(certDir, "pki/issued", args[i]+".crt"),
+					path.Join(certDir, "pki", "index.txt"),
+					path.Join(certDir, "pki", "index.txt.attr"),
+					path.Join(certDir, "pki", "certs_by_serial"),
+					path.Join(certDir, "pki", "serial"),
+					path.Join(certDir, "ccd", mainNetwork, args[i]),
 				}
 				git.Add(files)
 				git.Commit(files, msg)


### PR DESCRIPTION
Follow up of #414 , extracted from #415

The  `request` and `revoke` commands were not fulfilling properly the provided flags.
This PR is a pass on all the cobra commands to unify the flags