### PR TITLE
feat(easyvpn/config) allow specifying multiple CIDR per route with space (' ') as separator

### DIFF
--- a/cert/ccd/private/abayer
+++ b/cert/ccd/private/abayer
@@ -1,8 +1,8 @@
 # Client Configuration for user "abayer" in the VPN network "private"
 ifconfig-push 10.9.0.16 255.255.255.0
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -10,5 +10,5 @@ push "route 10.248.0.0 255.252.0.0"
 push "route 10.240.0.0 255.252.0.0"
 # public vnet
 push "route 10.244.0.0 255.252.0.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/danielbeck
+++ b/cert/ccd/private/danielbeck
@@ -1,26 +1,26 @@
 # Client Configuration for user "danielbeck" in the VPN network "private"
 ifconfig-push 10.9.0.5 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/dduportal
+++ b/cert/ccd/private/dduportal
@@ -1,26 +1,26 @@
 # Client Configuration for user "dduportal" in the VPN network "private"
 ifconfig-push 10.9.0.3 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/jayfranco_cb
+++ b/cert/ccd/private/jayfranco_cb
@@ -1,26 +1,26 @@
 # Client Configuration for user "jayfranco_cb" in the VPN network "private"
 ifconfig-push 10.9.0.2 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/kevingrdj
+++ b/cert/ccd/private/kevingrdj
@@ -1,26 +1,26 @@
 # Client Configuration for user "kevingrdj" in the VPN network "private"
 ifconfig-push 10.9.0.11 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/kohsuke
+++ b/cert/ccd/private/kohsuke
@@ -1,12 +1,12 @@
 # Client Configuration for user "kohsuke" in the VPN network "private"
 ifconfig-push 10.9.0.6 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -14,5 +14,5 @@ push "route 10.248.0.0 255.252.0.0"
 push "route 10.244.0.0 255.252.0.0"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/krisstern
+++ b/cert/ccd/private/krisstern
@@ -1,6 +1,6 @@
 # Client Configuration for user "krisstern" in the VPN network "private"
 ifconfig-push 10.9.0.15 255.255.255.0
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"

--- a/cert/ccd/private/markewaite
+++ b/cert/ccd/private/markewaite
@@ -1,26 +1,26 @@
 # Client Configuration for user "markewaite" in the VPN network "private"
 ifconfig-push 10.9.0.7 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/notmyfault
+++ b/cert/ccd/private/notmyfault
@@ -1,26 +1,26 @@
 # Client Configuration for user "notmyfault" in the VPN network "private"
 ifconfig-push 10.9.0.8 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/smerle
+++ b/cert/ccd/private/smerle
@@ -1,26 +1,26 @@
 # Client Configuration for user "smerle" in the VPN network "private"
 ifconfig-push 10.9.0.4 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/timja
+++ b/cert/ccd/private/timja
@@ -1,26 +1,26 @@
 # Client Configuration for user "timja" in the VPN network "private"
 ifconfig-push 10.9.0.9 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/cert/ccd/private/wfollonier
+++ b/cert/ccd/private/wfollonier
@@ -1,26 +1,26 @@
 # Client Configuration for user "wfollonier" in the VPN network "private"
 ifconfig-push 10.9.0.10 255.255.255.0
-# archives.jenkins.io VM
+# archives.jenkins.io
 push "route 46.101.121.132 255.255.255.255"
-# aws.ci.jenkins.io VM
+# aws.ci.jenkins.io
 push "route 18.217.202.59 255.255.255.255"
-# azure.ci.jenkins.io VM
+# azure.ci.jenkins.io
 push "route 172.200.138.43 255.255.255.255"
-# census.jenkins.io VM
+# census.jenkins.io
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
 # cert-ci-jenkins-io-sponsorship vnet
 push "route 10.205.0.0 255.255.255.0"
-# eks_cijenkinsioagents2_1 VM
+# eks_cijenkinsioagents2_1
 push "route 3.149.71.89 255.255.255.255"
-# eks_cijenkinsioagents2_2 VM
+# eks_cijenkinsioagents2_2
 push "route 3.149.48.23 255.255.255.255"
 # infra-ci-jenkins-io vnet
 push "route 10.5.0.0 255.255.252.0"
 # infra-ci-jenkins-io-sponsorship vnet
 push "route 10.206.0.0 255.255.252.0"
-# pkg.origin.jenkins.io VM
+# pkg.origin.jenkins.io
 push "route 52.202.51.185 255.255.255.255"
 # private vnet
 push "route 10.248.0.0 255.252.0.0"
@@ -32,11 +32,11 @@ push "route 10.244.0.0 255.252.0.0"
 push "route 10.253.0.0 255.255.248.0"
 # public-jenkins-sponsorship vnet
 push "route 10.200.0.0 255.252.0.0"
-# testissues.jenkins.io VM
+# testissues.jenkins.io
 push "route 52.88.217.28 255.255.255.255"
 # trusted-ci-jenkins-io vnet
 push "route 10.252.0.0 255.255.248.0"
 # trusted-ci-jenkins-io-sponsorship vnet
 push "route 10.204.0.0 255.255.255.0"
-# usage.jenkins.io VM
+# usage.jenkins.io
 push "route 52.204.62.78 255.255.255.255"

--- a/config.yaml
+++ b/config.yaml
@@ -20,8 +20,7 @@ networks:
       census.jenkins.io: 52.202.38.86/32
       azure.ci.jenkins.io: 172.200.138.43/32
       aws.ci.jenkins.io: 18.217.202.59/32
-      eks_cijenkinsioagents2_1: 3.149.71.89/32
-      eks_cijenkinsioagents2_2: 3.149.48.23/32
+      eks_cijenkinsioagents2: 3.149.71.89/32 3.149.48.23/32
       testissues.jenkins.io: 52.88.217.28/32
 users:
   abayer:


### PR DESCRIPTION
As we want to keep track of IP associated to multi-valued DNS records (usually AWS ELBs), it is easier if we specify multiple IPs per network route