### PR TITLE
chore(updatecli) track multivalued IPs

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -40,6 +40,9 @@ networks:
       pkg.origin.jenkins.io:
         report_url: https://reports.jenkins.io/jenkins-infra-data-reports/aws.json
         report_query: .pkg\.origin\.jenkins\.io.service_ips.ipv4
-    multivalued_servers:
-      eks_cijenkinsioagents2: EFD41748F9C38AAB83FA81F34C59B313.gr7.us-east-2.eks.amazonaws.com
-      testissues.jenkins.io: null
+      eks_cijenkinsioagents2:
+        report_url: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+        report_query: .aws\.ci\.jenkins\.io.cijenkinsio-agents-2.cluster_endpoint
+        resolve_dns: true
+      testissues.jenkins.io:
+        resolve_dns: true


### PR DESCRIPTION
We still have some routes which IPs are not updated "live". This PR adds support in the updatecli manifest to track them.

The idea is to resolve the DNS so we can update multiple IPs.