### PR TITLE
feat(config) add a new route for `dockerhubmirror.privatelink.azurecr.io`

### DIFF
--- a/cert/ccd/private/danielbeck
+++ b/cert/ccd/private/danielbeck
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/dduportal
+++ b/cert/ccd/private/dduportal
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/jayfranco_cb
+++ b/cert/ccd/private/jayfranco_cb
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/kevingrdj
+++ b/cert/ccd/private/kevingrdj
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/markewaite
+++ b/cert/ccd/private/markewaite
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/notmyfault
+++ b/cert/ccd/private/notmyfault
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/smerle
+++ b/cert/ccd/private/smerle
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/timja
+++ b/cert/ccd/private/timja
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/cert/ccd/private/wfollonier
+++ b/cert/ccd/private/wfollonier
@@ -8,6 +8,8 @@ push "route 18.217.202.59 255.255.255.255"
 push "route 52.202.38.86 255.255.255.255"
 # cert-ci-jenkins-io vnet
 push "route 10.252.8.0 255.255.248.0"
+# dockerhubmirror.azurecr.io
+push "route 10.249.0.9 255.255.255.255"
 # eks_cijenkinsioagents2_1
 push "route 3.149.48.23 255.255.255.255"
 # eks_cijenkinsioagents2_2

--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,7 @@ networks:
       aws.ci.jenkins.io: 18.217.202.59/32
       eks_cijenkinsioagents2: 3.149.48.23/32 3.149.71.89/32
       testissues.jenkins.io: 35.163.3.64/32 52.41.215.149/32
+      dockerhubmirror.azurecr.io: 10.249.0.9/32
 users:
   abayer:
     id: 16


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4769

This PR allows admins to access the registry through VPN routing (as it is only reachable through private endpoints)