### PR TITLE
chore(updatecli) update tracking of IP with usage.jenkins.io in DigitalOcean and deprecation messages with JSON resource

### DIFF
--- a/updatecli/updatecli.d/restricted-ips.yaml.tpl
+++ b/updatecli/updatecli.d/restricted-ips.yaml.tpl
@@ -22,6 +22,7 @@ sources:
   {{ $subnet }}-cidr:
     kind: json
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
       key: .vnets.{{ $subnet }}-vnet.[0]
   {{ end }}
@@ -45,6 +46,7 @@ sources:
       {{ end }}
     kind: json
     spec:
+      engine: dasel/v2
       file: {{ $server_data.report_url }}
       key: {{ $server_data.report_query }}
     {{ end }}

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -24,7 +24,7 @@ networks:
         report_url: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
         report_query: .aws\.ci\.jenkins\.io.service_ips.ipv4
       usage.jenkins.io:
-        report_url: https://reports.jenkins.io/jenkins-infra-data-reports/aws.json
+        report_url: https://reports.jenkins.io/jenkins-infra-data-reports/digitalocean.json
         report_query: .usage\.jenkins\.io.service_ips.ipv4
       census.jenkins.io:
         report_url: https://reports.jenkins.io/jenkins-infra-data-reports/aws.json


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/docker-openvpn/pull/464

Following #463 , related to https://github.com/jenkins-infra/helpdesk/issues/1626