### PR TITLE
cleanup(config,updatecli) remove dockerhubmirror setup as it is routed through private vnet

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,6 @@ networks:
       census.jenkins.io: 64.226.127.59/32
       aws.ci.jenkins.io: 18.217.202.59/32
       eks_cijenkinsioagents2: 3.149.48.23/32 3.149.71.89/32
-      dockerhubmirror.azurecr.io: 20.49.102.134/32
 users:
   abayer:
     id: 16

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -33,7 +33,5 @@ networks:
         report_url: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
         report_query: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.cluster_endpoint
         resolve_dns: true
-      dockerhubmirror.azurecr.io:
-        resolve_dns: true
 
 certificates: abayer,danielbeck,dduportal,hlemeur,jay_jenkins,kevingrdj,kohsuke,krisstern,markewaite,notmyfault,smerle,timja,wfollonier


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5111