### PR TITLE
Add privatek8s-sponsored route for krisstern

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,6 +53,7 @@ users:
         - public
         - private
         - public-db
+        - privatek8s-sponsored
   markewaite:
     id: 7
     all_routes: true


### PR DESCRIPTION
Ref: 
- jenkins-infra/helpdesk#5209

Grants krisstern access to the privatek8s-sponsored cluster (10.6.0.0/21), where release.ci.jenkins.io (and infra.ci.jenkins.io controller) now live following the privatek8s -> privatek8s-sponsored migration.



