### PR TITLE
chore(updatecli) fix golang manifest to also bump Golang in the `Dockerfile`'s `easyvpn` build stage

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -45,6 +45,18 @@ targets:
       matchpattern: 'GOLANG_VERSION \?= .*'
       replacepattern: 'GOLANG_VERSION ?= {{ source "latestGoVersion" }}'
     scmid: default
+  updateDockerfile:
+    name: "Update the golang version used by the build stage in the Dockerfile"
+    kind: dockerfile
+    sourceid: latestGoVersion
+    spec:
+      file: Dockerfile
+      stage: easyvpn
+      instruction:
+        keyword: FROM
+        matcher: golang
+    scmid: default
+
 
 actions:
   default:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/docker-openvpn/pull/546#pullrequestreview-5010040598

Caused by (and fixup of) https://github.com/jenkins-infra/docker-openvpn/pull/515 which did not have a follow-up PR.

We only caught this problem with the minor bump in Golang (1.26.x -> 1.27.x) as all 1.26.x patches where not enough to fail the build.